### PR TITLE
refactor: メタデータ注入経路を frontmatter 優先に一本化 (#36)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,21 +243,33 @@ YAML形式でパレットに表示するコマンドを定義します。
 
 ### 使用方法
 
-これらの設定は`\crefname`を通じてLaTeXに渡され、以下のように使用できます：
-
-```markdown
-![画像の説明](image.png){#fig:example}
-
-図\ref{fig:example}を参照
-```
-
-またはpandoc-crossrefを使用：
+これらの設定は Pandoc のメタデータ（pandoc-crossref の `figureTitle` / `figPrefix` / `tableTitle` / `tblPrefix` / `listingTitle` / `lstPrefix` / `eqnPrefix`）として渡されます。Pandoc Crossref が有効な場合は、図・表・コード・数式のキャプション語と参照接頭辞がこのメタデータから適用されます。
 
 ```markdown
 ![画像の説明](image.png){#fig:example}
 
 [@fig:example]を参照
 ```
+
+### 文書ごとに frontmatter で上書きする
+
+ラベルとプレフィックスは **文書の frontmatter で上書きできます**。優先順位は `frontmatter > プロファイル > デフォルト` です。プロファイル設定を変えずに、特定の文書だけキャプション語を切り替えたい場合に便利です。
+
+frontmatter に対応するメタデータキーを書くと、プロファイル設定より優先されます。
+
+```yaml
+---
+figureTitle: 図
+figPrefix: 図
+tableTitle: 表
+tblPrefix: 表
+listingTitle: コード
+lstPrefix: コード
+eqnPrefix: 式
+---
+```
+
+> **注意**: 数式キャプション語（`Equation`）は pandoc-crossref に対応する Title 系メタデータキーがなく、参照接頭辞の `eqnPrefix` のみ上書き可能です。Pandoc Crossref が無効の場合は frontmatter 上書きの効かない LaTeX ネイティブキャプション名のフォールバックが使われます。
 
 ---
 

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -119,7 +119,8 @@ const en = {
   notice_preamble_copied: "Preamble copied to clipboard.",
 
   heading_localization: "Localization (Labels & Prefixes)",
-  heading_localization_desc: "Set the labels used for captions and cross-references.",
+  heading_localization_desc:
+    "Set the labels used for captions and cross-references. You can override these per document via frontmatter keys (figureTitle / figPrefix / tableTitle / tblPrefix / listingTitle / lstPrefix / eqnPrefix), which take precedence over the profile settings.",
   placeholder_label: "Label",
   placeholder_prefix: "Prefix",
   label_figures: "Figures (Label / Prefix)",

--- a/src/lang/locale/ja.ts
+++ b/src/lang/locale/ja.ts
@@ -120,7 +120,8 @@ const ja: Record<TranslationKeys, string> = {
   notice_preamble_copied: "プリアンブルをコピーしました。",
 
   heading_localization: "ラベルと言語設定",
-  heading_localization_desc: "キャプションや参照に使うラベルとプレフィックスを設定します。",
+  heading_localization_desc:
+    "キャプションや参照に使うラベルとプレフィックスを設定します。文書の frontmatter に figureTitle / figPrefix / tableTitle / tblPrefix / listingTitle / lstPrefix / eqnPrefix を書くと、このプロファイル設定より優先されます（文書ごとに上書き可能）。",
   placeholder_label: "ラベル",
   placeholder_prefix: "プレフィックス",
   label_figures: "図（ラベル / プレフィックス）",

--- a/src/services/convertService.test.ts
+++ b/src/services/convertService.test.ts
@@ -90,6 +90,72 @@ describe("convertCurrentPage", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
+  it("crossref-ON ではプリアンブルに \\renewcommand を注入せず --metadata-file でメタデータを渡す", async () => {
+    // frontmatter 優先を実現するため、crossref-ON 時はキャプション語をメタデータ経路
+    // （--metadata-file / frontmatter）に一本化し、\renewcommand との二重管理を解消する。
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "mdtex-test-xref-on-"));
+    const inputPath = path.join(tmpDir, "note.md");
+    await fs.writeFile(inputPath, "# Title\nHello", "utf8");
+
+    const app = new App();
+    app.vault.adapter = new FileSystemAdapter(tmpDir);
+    app.workspace.getActiveFile = () => ({ path: "note.md" }) as TFile;
+    app.workspace.activeLeaf = null;
+
+    const profile = { ...DEFAULT_PROFILE, outputDirectory: tmpDir, usePandocCrossref: true };
+    const settings = { ...DEFAULT_SETTINGS, profiles: { Default: profile }, activeProfile: "Default" };
+    const ctx: PluginContext = { app, settings, getActiveProfileSettings: () => profile };
+
+    mockedRunCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await convertCurrentPage(ctx, { runMarkdownlintFix: noopLintFix }, "pdf");
+
+    const [, args] = mockedRunCommand.mock.calls[0];
+    expect(args).toContain("--metadata-file");
+
+    const preamble = await fs.readFile(path.join(tmpDir, "note.preamble.tex"), "utf8");
+    expect(preamble).not.toContain("\\renewcommand{\\figurename}");
+    expect(preamble).not.toContain("\\renewcommand{\\tablename}");
+
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("crossref-OFF ではプロファイル値で \\renewcommand を注入するフォールバックが残る", async () => {
+    // crossref-OFF 時はメタデータの消費先がないため、プロファイル値で LaTeX ネイティブの
+    // キャプション名を上書きするフォールバックを維持する（後方互換）。
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "mdtex-test-xref-off-"));
+    const inputPath = path.join(tmpDir, "note.md");
+    await fs.writeFile(inputPath, "# Title\nHello", "utf8");
+
+    const app = new App();
+    app.vault.adapter = new FileSystemAdapter(tmpDir);
+    app.workspace.getActiveFile = () => ({ path: "note.md" }) as TFile;
+    app.workspace.activeLeaf = null;
+
+    const profile = {
+      ...DEFAULT_PROFILE,
+      outputDirectory: tmpDir,
+      usePandocCrossref: false,
+      figureLabel: "図",
+    };
+    const settings = { ...DEFAULT_SETTINGS, profiles: { Default: profile }, activeProfile: "Default" };
+    const ctx: PluginContext = { app, settings, getActiveProfileSettings: () => profile };
+
+    mockedRunCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await convertCurrentPage(ctx, { runMarkdownlintFix: noopLintFix }, "pdf");
+
+    // crossref-OFF では crossref 専用メタデータに消費先がないため、--metadata-file
+    // を渡さず LaTeX ネイティブの \renewcommand フォールバックのみを使う。
+    const [, offArgs] = mockedRunCommand.mock.calls[0];
+    expect(offArgs).not.toContain("--metadata-file");
+
+    const preamble = await fs.readFile(path.join(tmpDir, "note.preamble.tex"), "utf8");
+    expect(preamble).toContain("\\renewcommand{\\figurename}{図}");
+
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
   it("Pandoc が異常終了した場合はエラーノーティスを出す", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "mdtex-test-err-"));
     const inputPath = path.join(tmpDir, "note.md");

--- a/src/services/convertService.ts
+++ b/src/services/convertService.ts
@@ -21,7 +21,12 @@ import { expandTransclusions } from "../utils/transclusion";
 import type { PluginContext } from "./lintService";
 import { rasterizeMermaidBlocks } from "../utils/mermaidRasterizer";
 import { t } from "../lang/helpers";
-import { buildPandocCommand, OutputFormat, PandocCommandResult } from "./pandocCommandBuilder";
+import {
+  buildPandocCommand,
+  buildLabelMetadataYaml,
+  OutputFormat,
+  PandocCommandResult,
+} from "./pandocCommandBuilder";
 import { runCommand } from "../utils/processRunner";
 import { joinFsPath, normalizeResourcePathList } from "../utils/pathHelpers";
 
@@ -37,6 +42,25 @@ async function createTempLuaFilter(): Promise<{ luaPath: string; tempDir: string
     const luaPath = joinFsPath(tempDir, fileName);
     await fs.writeFile(luaPath, CALLOUT_LUA_FILTER, "utf8");
     return { luaPath, tempDir };
+  } catch (error) {
+    await fs.rm(tempDir, { recursive: true, force: false }).catch(() => {});
+    throw error;
+  }
+}
+
+// プロファイル既定値のラベル／接頭辞を Pandoc メタデータ YAML として一時生成する。
+// 値が全て空なら null を返し、呼び出し側は --metadata-file を省略する。
+async function createTempMetadataFile(
+  profile: ProfileSettings,
+): Promise<{ metadataPath: string; tempDir: string } | null> {
+  const body = buildLabelMetadataYaml(profile);
+  if (!body) return null;
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mdtex-metadata-"));
+  try {
+    const fileName = `labels-${Date.now()}-${Math.random().toString(16).slice(2)}.yaml`;
+    const metadataPath = joinFsPath(tempDir, fileName);
+    await fs.writeFile(metadataPath, body, "utf8");
+    return { metadataPath, tempDir };
   } catch (error) {
     await fs.rm(tempDir, { recursive: true, force: false }).catch(() => {});
     throw error;
@@ -227,23 +251,29 @@ export async function convertCurrentPage(
       }
     }
 
-    // ユーザー設定プリアンブルにコールアウト定義を付与し、listing名の上書きを加える
+    // ユーザー設定プリアンブルにコールアウト定義を付与する
     // プリアンブルは生 .tex として --include-in-header で渡すため、YAML(header-includes) 時代の
     // クリーニングは行わず、ユーザー設定 + コールアウト定義をそのまま素通りさせる。
     const baseHeader = activeProfile.headerIncludes || "";
     const withCallout = baseHeader.includes("obsidiancallout")
       ? baseHeader
       : `${baseHeader.trim()}\n\n${CALLOUT_PREAMBLE}`.trim();
-    const headerWithListings = appendLabelOverrides(withCallout, {
-      figureLabel: activeProfile.figureLabel,
-      figPrefix: activeProfile.figPrefix,
-      tableLabel: activeProfile.tableLabel,
-      tblPrefix: activeProfile.tblPrefix,
-      codeLabel: activeProfile.codeLabel,
-      lstPrefix: activeProfile.lstPrefix,
-      equationLabel: activeProfile.equationLabel,
-      eqnPrefix: activeProfile.eqnPrefix,
-    });
+    // crossref-ON 時はキャプション語／参照接頭辞をメタデータ経路
+    // （--metadata-file / frontmatter）に一本化し、\renewcommand との二重管理を避ける。
+    // crossref-OFF 時はメタデータの消費先がないため、プロファイル値で LaTeX ネイティブの
+    // キャプション名（\figurename 等）を上書きするフォールバックを残す。
+    const headerWithListings = activeProfile.usePandocCrossref
+      ? withCallout
+      : appendLabelOverrides(withCallout, {
+          figureLabel: activeProfile.figureLabel,
+          figPrefix: activeProfile.figPrefix,
+          tableLabel: activeProfile.tableLabel,
+          tblPrefix: activeProfile.tblPrefix,
+          codeLabel: activeProfile.codeLabel,
+          lstPrefix: activeProfile.lstPrefix,
+          equationLabel: activeProfile.equationLabel,
+          eqnPrefix: activeProfile.eqnPrefix,
+        });
 
     //
     // LaTeX の \maketitle はタイトルページを強制的に plain スタイルにする。
@@ -507,6 +537,20 @@ async function buildPandocExecutionPlan(params: {
   const docxLua = resolveDocxLuaFilter(params.profile, params.format);
   if (docxLua) luaFilters.push(docxLua);
 
+  // プロファイル既定値をメタデータとして渡し、文書 frontmatter で上書き可能にする。
+  // ただし figureTitle / figPrefix 等は pandoc-crossref 専用メタデータなので、
+  // crossref-OFF では消費先がなく無意味。その場合は LaTeX ネイティブの
+  // \renewcommand フォールバック（convertCurrentPage 側）に任せ、不要な
+  // 一時ファイル生成を避ける。
+  const metadata = params.profile.usePandocCrossref
+    ? await createTempMetadataFile(params.profile)
+    : null;
+  let metadataFile: string | undefined;
+  if (metadata) {
+    metadataFile = metadata.metadataPath;
+    tempFiles.push(metadata.metadataPath, metadata.tempDir);
+  }
+
   try {
     const command = buildPandocCommand({
       profile: params.profile,
@@ -514,6 +558,7 @@ async function buildPandocExecutionPlan(params: {
       inputPath: params.useStdin ? undefined : params.inputPath,
       outputPath: params.outputFile,
       headerPath: params.headerFilePath,
+      metadataFile,
       workingDir: params.workingDir,
       extraArgs: params.pandocExtraArgs,
       luaFilters,

--- a/src/services/pandocCommandBuilder.test.ts
+++ b/src/services/pandocCommandBuilder.test.ts
@@ -4,7 +4,7 @@
 // Related: src/services/pandocCommandBuilder.ts, src/services/profileManager.ts, vitest.config.ts, plans.md
 
 import { describe, expect, it } from "vitest";
-import { buildPandocCommand } from "./pandocCommandBuilder";
+import { buildPandocCommand, buildLabelMetadataYaml } from "./pandocCommandBuilder";
 import { createDefaultProfile } from "./profileManager";
 
 describe("buildPandocCommand", () => {
@@ -95,5 +95,114 @@ describe("buildPandocCommand", () => {
 
     expect(result.args).toContain("--resource-path");
     expect(result.args).toContain("/vault/root");
+  });
+});
+
+describe("ラベルメタデータのメタデータ-file 移行", () => {
+  it("buildPandocCommand は -M でキャプション語／接頭辞を渡さない（frontmatter 上書きを阻害しない）", () => {
+    // コマンドライン -M は frontmatter より常に優先されてしまうため、文書ごとの上書きを
+    // 可能にするには -M を廃止し --metadata-file に寄せる必要がある。これを回帰防止のため検証する。
+    const profile = createDefaultProfile();
+    const result = buildPandocCommand({
+      profile,
+      format: "pdf",
+      outputPath: "/tmp/out.pdf",
+      workingDir: "/tmp",
+    });
+
+    // 削除対象の 8 項目（legacy kebab の listing-title 含む）が残っていないこと
+    for (const key of [
+      "figureTitle",
+      "figPrefix",
+      "tableTitle",
+      "tblPrefix",
+      "listingTitle",
+      "listing-title",
+      "lstPrefix",
+      "eqnPrefix",
+    ]) {
+      const asM = `-M ${key}=`;
+      expect(result.args.some(a => a.startsWith(asM))).toBe(false);
+    }
+    expect(result.args).not.toContain("-M");
+  });
+
+  it("buildPandocCommand は metadataFile 指定時に --metadata-file を展開する", () => {
+    const profile = createDefaultProfile();
+    const result = buildPandocCommand({
+      profile,
+      format: "pdf",
+      outputPath: "/tmp/out.pdf",
+      workingDir: "/tmp",
+      metadataFile: "/tmp/mdtex-metadata-1/labels.yaml",
+    });
+
+    const idx = result.args.indexOf("--metadata-file");
+    expect(idx).toBeGreaterThan(-1);
+    expect(result.args[idx + 1]).toBe("/tmp/mdtex-metadata-1/labels.yaml");
+  });
+
+  it("metadataFile 未指定時は --metadata-file を渡さない", () => {
+    const profile = createDefaultProfile();
+    const result = buildPandocCommand({
+      profile,
+      format: "pdf",
+      outputPath: "/tmp/out.pdf",
+      workingDir: "/tmp",
+    });
+    expect(result.args).not.toContain("--metadata-file");
+  });
+
+  it("buildLabelMetadataYaml はプロファイル既定値を crossref メタデータキーにマップする", () => {
+    const profile = createDefaultProfile();
+    profile.figureLabel = "図";
+    profile.figPrefix = "図";
+    profile.tableLabel = "表";
+    profile.tblPrefix = "表";
+    profile.codeLabel = "コード";
+    profile.lstPrefix = "コード";
+    profile.eqnPrefix = "式";
+
+    const yaml = buildLabelMetadataYaml(profile);
+
+    expect(yaml).toContain('figureTitle: "図"');
+    expect(yaml).toContain('figPrefix: "図"');
+    expect(yaml).toContain('tableTitle: "表"');
+    expect(yaml).toContain('tblPrefix: "表"');
+    expect(yaml).toContain('listingTitle: "コード"');
+    expect(yaml).toContain('lstPrefix: "コード"');
+    expect(yaml).toContain('eqnPrefix: "式"');
+    // equationLabel は crossref の Title 系キーに対応しないため含まれない
+    expect(yaml).not.toContain("equation");
+    // legacy kebab キーは含まれない
+    expect(yaml).not.toContain("listing-title");
+  });
+
+  it("buildLabelMetadataYaml は空の値を省略し、全空なら空文字列を返す", () => {
+    const partial = createDefaultProfile();
+    partial.figPrefix = "";
+    partial.tblPrefix = "   ";
+    const partialYaml = buildLabelMetadataYaml(partial);
+    expect(partialYaml).not.toContain("figPrefix");
+    expect(partialYaml).not.toContain("tblPrefix");
+    expect(partialYaml).toContain('figureTitle: "Figure"');
+
+    const empty = createDefaultProfile();
+    empty.figureLabel = "";
+    empty.figPrefix = "";
+    empty.tableLabel = "";
+    empty.tblPrefix = "";
+    empty.codeLabel = "";
+    empty.lstPrefix = "";
+    empty.eqnPrefix = "";
+    expect(buildLabelMetadataYaml(empty)).toBe("");
+  });
+
+  it("buildLabelMetadataYaml はダブルクオートとバックスラッシュをエスケープする", () => {
+    const profile = createDefaultProfile();
+    profile.figureLabel = 'a"b\\c';
+    const yaml = buildLabelMetadataYaml(profile);
+    // YAML 二重引用符内で " と \\ がエスケープされていること
+    expect(yaml).toContain('figureTitle: "a\\"b\\\\c"');
   });
 });

--- a/src/services/pandocCommandBuilder.ts
+++ b/src/services/pandocCommandBuilder.ts
@@ -15,6 +15,10 @@ export interface PandocCommandOptions {
   workingDir: string;
   inputPath?: string;
   headerPath?: string;
+  // プロファイル既定値のラベル／接頭辞を Pandoc メタデータとして渡す一時 YAML のパス。
+  // `-M` ではなく `--metadata-file` 経由にすることで、文書の frontmatter が
+  // プロファイル既定値より優先される（Pandoc の precedence: frontmatter > metadata-file）。
+  metadataFile?: string;
   extraArgs?: string[];
   luaFilters?: string[];
   resourcePath?: string;
@@ -35,6 +39,10 @@ export function buildPandocCommand(options: PandocCommandOptions): PandocCommand
   }
 
   args.push(...getInputFormatArgs(options.format));
+
+  if (options.metadataFile) {
+    args.push("--metadata-file", normalizeFsPath(options.metadataFile));
+  }
 
   if (options.headerPath) {
     args.push("--include-in-header", normalizeFsPath(options.headerPath));
@@ -69,14 +77,10 @@ export function buildPandocCommand(options: PandocCommandOptions): PandocCommand
     args.push("-F", crossrefFilter);
   }
 
-  args.push("-M", `figureTitle=${profile.figureLabel}`);
-  args.push("-M", `figPrefix=${profile.figPrefix}`);
-  args.push("-M", `tableTitle=${profile.tableLabel}`);
-  args.push("-M", `tblPrefix=${profile.tblPrefix}`);
-  args.push("-M", `listingTitle=${profile.codeLabel}`);
-  args.push("-M", `listing-title=${profile.codeLabel}`);
-  args.push("-M", `lstPrefix=${profile.lstPrefix}`);
-  args.push("-M", `eqnPrefix=${profile.eqnPrefix}`);
+  // 図・表・コード・数式のキャプション語／参照接頭辞は `--metadata-file` 経由で
+  // プロファイル既定値を渡す。コマンドライン `-M` で渡すと frontmatter より優先
+  // されてしまい文書ごとの上書きが効かなくなるため、metadata-file に一本化する。
+  // YAML の生成は buildLabelMetadataYaml、ファイル化は buildPandocExecutionPlan が担う。
 
   if (profile.useMarginSize) args.push("-V", `geometry:margin=${profile.marginSize}`);
   if (!profile.usePageNumber) args.push("-V", "pagestyle=empty");
@@ -101,11 +105,60 @@ export function buildPandocCommand(options: PandocCommandOptions): PandocCommand
   return { command: pandocPath, args };
 }
 
+/**
+ * プロファイルのラベル／接頭辞設定を Pandoc（pandoc-crossref）のメタデータ YAML に直す。
+ *
+ * プロファイル項目と Pandoc/crossref メタデータキーの対応は以下のとおり。
+ *   figureLabel -> figureTitle （図キャプション語）
+ *   figPrefix   -> figPrefix   （図の参照接頭辞）
+ *   tableLabel  -> tableTitle  （表キャプション語）
+ *   tblPrefix   -> tblPrefix   （表の参照接頭辞）
+ *   codeLabel   -> listingTitle（コードキャプション語）
+ *   lstPrefix   -> lstPrefix   （コードの参照接頭辞）
+ *   eqnPrefix   -> eqnPrefix   （数式の参照接頭辞）
+ *
+ * なお `equationLabel`（"Equation"）は crossref に対応する Title 系メタデータキーが
+ * 存在しないためここには含まない。crossref-OFF 時の LaTeX ネイティブキャプション
+ * フォールバック（`appendLabelOverrides`）経由でのみ意味を持つ。
+ *
+ * すべての値が空の場合は空文字列を返す（呼び出し側で metadata-file を省略する）。
+ * 返す YAML は `--metadata-file` に渡すため、文書 frontmatter よりも優先度が低く、
+ * frontmatter > プロファイル既定値 のフォールバックが自然に成立する。
+ */
+export function buildLabelMetadataYaml(profile: ProfileSettings): string {
+  const quote = (v: string) => '"' + (v ?? "").replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
+  const entries: Array<[string, string]> = [
+    ["figureTitle", profile.figureLabel],
+    ["figPrefix", profile.figPrefix],
+    ["tableTitle", profile.tableLabel],
+    ["tblPrefix", profile.tblPrefix],
+    ["listingTitle", profile.codeLabel],
+    ["lstPrefix", profile.lstPrefix],
+    ["eqnPrefix", profile.eqnPrefix],
+  ];
+  const lines = entries
+    .filter(([, v]) => (v ?? "").trim() !== "")
+    .map(([k, v]) => `${k}: ${quote(v)}`);
+  return lines.length ? lines.join("\n") + "\n" : "";
+}
+
+/**
+ * Pandoc の入力フォーマット引数（`-f`）を返す。
+ *
+ * 全出力形式（pdf/latex/docx）で共通の Markdown 拡張セットを明示する。
+ * Pandoc 3.x のデフォルト `markdown` は `+raw_tex +raw_html +fenced_divs
+ * +raw_attribute +fenced_code_attributes` をすべて ON で含むため、これらは
+ * 挙動を変えない冗長な再指定になるが、プラグインが依存する構文
+ * （生 LaTeX / `:::` fenced div / `{=latex}` `{=openxml}` raw block /
+ * `{#lst:...}` コード属性）を Pandoc のバージョン差や設定ドリフトに
+ * 依存せず安定して有効化するため明示する。
+ *
+ * `format` は歴史的に出力形式ごとの分岐に使われていた引数だが、現状は
+ * すべて同じ結果を返す。呼び出し側（`buildPandocCommand`）の意図と API
+ * 安定性を保つため受け取り続け、分岐は行わない。
+ */
 export function getInputFormatArgs(format: string): string[] {
-  if (format === "docx") {
-    return ["-f", "markdown+raw_html+fenced_divs+raw_attribute"];
-  }
-  return ["-f", "markdown"];
+  return ["-f", "markdown+raw_tex+raw_html+fenced_divs+raw_attribute+fenced_code_attributes"];
 }
 
 export function filterPandocExtrasForFormat(extras: string[], format: string): string[] {


### PR DESCRIPTION
## 概要

Issue #36 の対応。図・表・コード・数式のキャプション語／参照接頭辞の制御を、**文書の frontmatter で上書き可能** にするリファクタリングです。

## 背景

従来はプロファイル（グローバル設定）からのみ決まり、Pandoc コマンド構築関数が常に `-M figureTitle=…` 等（8項目）を固定で渡していた。さらにプリアンブル組み立てが同じ値を `\renewcommand{\figurename}{…}` 等でも埋め込んでおり、`-M` と LaTeX マクロの **二重管理** になっていた。

### 設計の要（Pandoc の優先順位）

Pandoc のメタデータ優先順位は **`-M`（CLI） > frontmatter（文書内） > `--metadata-file` > defaults**。つまり従来の `-M` 渡しでは frontmatter で上書きできない。そのため：

- **D2**: `-M` を全廃し、プロファイル既定値を `--metadata-file`（一時YAML）で渡す → frontmatter が自然に優先される
- **D3**: crossref-ON 時はメタデータ経路に一本化し `\renewcommand` 重複注入を削除。crossref-OFF 時はメタデータの消費先がないためプロファイル値による `\renewcommand` フォールバックを残す

優先順位ポリシー `frontmatter > プロファイル > デフォルト` は **pandoc 3.7.0.2 + pandoc-crossref で実証検証済み**（review_fixer 内でエンドツーエンドの LaTeX レンダリングを含めて確認）。

## 変更内容

- `src/services/pandocCommandBuilder.ts`
  - `-M figureTitle=…` 等 8 項目（legacy kebab `listing-title` 含む）を廃止
  - `metadataFile` オプションを追加し `--metadata-file` で渡すよう変更
  - プロファイル値 → crossref メタデータキーへのマッピングを行う純粋関数 `buildLabelMetadataYaml` を追加
- `src/services/convertService.ts`
  - プロファイル既定値を一時YAMLに書き出す `createTempMetadataFile` を追加
  - `appendLabelOverrides`（`\renewcommand`）と `createTempMetadataFile` を **`usePandocCrossref` で対称的にゲート化**（crossref-ON: メタデータ経路のみ、crossref-OFF: `\renewcommand` フォールバックのみ）
- `src/lang/locale/{ja,en}.ts`: 設定タブのセクション説明に frontmatter 上書き可能を明記（D6）
- `docs/configuration.md`: 「文書ごとに frontmatter で上書きする」セクションを追加（D6）

## Acceptance criteria

- [x] frontmatter に `figureTitle: 図` 等を書くと、出力のキャプション語が「図」になる（実証検証済み）
- [x] frontmatter に指定がなければプロファイル値が使われる（後方互換、実証検証済み）
- [x] メタデータ注入経路が `-M`/frontmatter（`--metadata-file`）に一本化され、crossref-ON 時のプリアンブルへの `\renewcommand` 重複注入が削除される
- [x] 設定タブのヘルプテキストが「frontmatter で文書ごとに上書き可能」を明記している

## 検証

- `tsc --noEmit` → exit 0
- `eslint src/` → exit 0
- `vitest run` → 5 ファイル / **32 テスト全合格**（新規 8 テスト追加：`-M` 廃止 / `--metadata-file` 展開 / YAML 生成・エスケープ・空値省略 / crossref ON-OFF 挙動の対称性）
- pre-commit / pre-push フック（build + test）も通過

## 合意事項（Triage Notes #36 より）

D1–D7 の推奨案すべてで合意済み。詳細は https://github.com/Mekann2904/obsidian-mdtex-plugin/issues/36#issuecomment-4738066016

## Out of scope（Issue 準拠）

- 新しいラベル種別の追加
- pandoc-crossref の設定項目自体の変更

## 残リスク（メモ）

- 本機能は Pandoc のメタデータ優先順位に依存する。現行 3.7.0.2 で検証済みだが、将来の Pandoc が順位を変えると frontmatter 上書きが静かに効かなくなる可能性あり（ユニットテストでは捕捉不可）。

Closes #36