### PR TITLE
docs(agents): engineering skills 設定を復元（#35 revert の巻き込み削除を修正）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Agents
+
+このリポジトリで動作するコーディングエージェント向けの指示ファイル。
+ engineering skills（`triage`, `to-issues`, `to-prd`, `diagnose`, `tdd`, `improve-codebase-architecture`, `grill-with-docs` 等）が読む設定は以下のブロックと `docs/agents/` 配下の詳細ドキュメントを参照。
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues（`gh` CLI 使用）。詳細は `docs/agents/issue-tracker.md`。
+
+### Triage labels
+
+正規ロール名をそのまま使用（`bug`/`enhancement`/`needs-triage`/`needs-info`/`ready-for-agent`/`ready-for-human`/`wontfix`）。詳細は `docs/agents/triage-labels.md`。
+
+### Domain docs
+
+シングルコンテキスト（`CONTEXT.md` + `docs/adr/`）。詳細は `docs/agents/domain.md`。

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,65 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-models.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+This repo is **single-context**: one `CONTEXT.md` and `docs/adr/` at the repo root.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_
+
+## このリポジトリの現状
+
+`CONTEXT.md` / `docs/adr/` はまだ存在しない（生成は `grill-with-docs` が用語確定時に遅延生成）。
+
+生成前は、以下の既存ドキュメントをドメイン情報源として参照すること:
+
+- **`ARCHITECTURE.md`** — コンポーネント構成・データフロー・設計原則
+- **`docs/design-decisions.md`** — ADR 形式の主要決定（ADR-001 外部ツール採用 / ADR-002 TypeScript / ADR-003 esbuild / ADR-004 Vitest）
+- **各ソースファイル先頭の `// Purpose / Reason / Related` コメント** — 小粒な設計判断。領域を探る際は該当ファイルのヘッダーコメントを必ず読む。
+
+`docs/design-decisions.md` は正式な `docs/adr/` ではないが、同様の役割を果たすため、判断衝突の確認時はこれを ADR 群として扱うこと。

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,33 @@
+# Triage Labels
+
+The skills speak in terms of canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+Every triaged issue should have exactly one category role and one state role.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `bug`                      | `bug`                | Something is broken                      |
+| `enhancement`              | `enhancement`        | New feature or improvement               |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for a coding agent   |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the agent-ready triage label"), use the corresponding label string from this table.
+
+## このリポジトリでの整備状況
+
+- `bug`, `enhancement`, `wontfix` は GitHub 既定ラベルとして元から存在。
+- `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human` は本セットアップで `gh label create` により新規作成済み（2026-06-18）。
+
+ラベルの色は運用上の目安として以下を設定:
+
+| ラベル | 色 | 意味合い |
+| ------ | ---- | -------- |
+| `needs-triage` | `#fbca04`（黄） | 要評価 |
+| `needs-info` | `#d93f0b`（オレンジ赤） | 情報待ち |
+| `ready-for-agent` | `#0e8a16`（緑） | エージェント実行可能 |
+| `ready-for-human` | `#1d76db`（青） | 人間作業 |
+
+語彙を追加・変更したい場合はこの表の右列を編集し、対応する GitHub ラベルを作成・リネームすること。


### PR DESCRIPTION
## 概要

#34 エピック作業中に `AGENTS.md` および `docs/agents/*`（engineering skills 向け設定）が意図せず削除されていたのを復元する。

## 経緯（原因）

1. `bc32c75` で `AGENTS.md` + `docs/agents/{domain,issue-tracker,triage-labels}.md` を追加
2. PR #40（#35: 入力フォーマット統一）が 上記を取り込んだブランチから main へマージ
3. PR #42 で #40 を revert した際、**#35 の変更だけでなく上記4ファイルも巻き込んで削除**
4. 続く #35 の reapply（`9e07692`）では `42878f0`（#35 単体）のみ再適用され、消失した4ファイルは戻らなかった

## 修正内容

`bc32c75`（純追加コミット）を cherry-pick して4ファイルを復元。内容は元コミットと完全同一（`git diff bc32c75 HEAD` で差分0行を確認）。

## 影響範囲

- `package.json` / `manifest.json` / `versions.json` / `*.ts` は**無変更**（docs のみ）
- プラグインのビルド・型チェック・テストには影響しない
- エージェント（engineering skills）の設定参照が実ファイルと整合するようになる

## 関連

- エピック: #34
- 巻き込み発生元: PR #42 (revert of #40)

## チェックリスト

- [x] cherry-pick で競合なし
- [x] 復元内容が `bc32c75` と完全一致
- [x] ビルド関連ファイル無変更