### PR TITLE
refactor: header 組み立てを純粋関数 buildHeader に切り出し（issue #51）

### DIFF
--- a/src/services/convertService.ts
+++ b/src/services/convertService.ts
@@ -13,8 +13,7 @@ import {
   unwrapValidWikiLinks,
   stripObsidianComments,
 } from "../utils/markdownTransforms";
-import { appendLabelOverrides, ensureCodelistingEnvironment } from "../utils/latexPreamble";
-import { CALLOUT_PREAMBLE } from "../utils/calloutTheme";
+import { buildHeader } from "../utils/headerBuilder";
 import { CALLOUT_LUA_FILTER } from "../assets/callout-filter";
 import { DOCX_TEX_LUA_FILTER } from "../assets/docxTexFilter";
 import { MERMAID_STRIP_LUA_FILTER } from "../assets/mermaid-filter";
@@ -287,76 +286,17 @@ export async function convertCurrentPage(
       }
     }
 
-    // 文書テンプレート方式（ADR-007）: defaults 方式は文書の「枠」（プリアンブル・
-    // documentclass 系・ページ番号・キャプション名）を defaults file 側で管理する。
-    // 一方、CALLOUT_PREAMBLE（Obsidian コールアウト変換）と codelisting 環境定義
-    // （`--listings` 常時付与に伴う Pandoc 3.8+ 互換）と draftSnippet（Obsidian frontmatter
-    // 連動）は MdTex 固有レイヤとして方式に関わらず維持する。
-    const isDefaultsMode = isDefaultsTemplateMode(activeProfile);
-
-    // ユーザー設定プリアンブルにコールアウト定義を付与する
-    // プリアンブルは生 .tex として --include-in-header で渡すため、YAML(header-includes) 時代の
-    // クリーニングは行わず、ユーザー設定 + コールアウト定義をそのまま素通りさせる。
-    // defaults 方式では headerIncludes も defaults file 側の include-in-header で管理するため
-    // 空扱いとし、CALLOUT_PREAMBLE と codelisting 定義だけを残す。
-    const baseHeader = isDefaultsMode ? "" : activeProfile.headerIncludes || "";
-    // Pandoc 3.8+ は --listings 時にキャプション付きコードブロックを \begin{codelisting} で
-    // 出力する。codelisting 環境は DEFAULT_LATEX_PREAMBLE に定義済みだが、旧版からの移行等で
-    // 独自プリアンブルを持つ場合は定義が欠け「Environment codelisting undefined.」で停止するため、
-    // 欠けていれば冪等に補完する（コールアウト定義付与と同じ層で処理）。
-    // defaults 方式でも --listings を常時付与するため codelisting 補完は維持する。
-    const withCallout = ensureCodelistingEnvironment(
-      baseHeader.includes("obsidiancallout")
-        ? baseHeader
-        : `${baseHeader.trim()}\n\n${CALLOUT_PREAMBLE}`.trim(),
-    );
-    // crossref-ON 時はキャプション語／参照接頭辞をメタデータ経路
-    // （--metadata-file / frontmatter）に一本化し、\renewcommand との二重管理を避ける。
-    // crossref-OFF 時はメタデータの消費先がないため、プロファイル値で LaTeX ネイティブの
-    // キャプション名（\figurename 等）を上書きするフォールバックを残す。
-    // いずれにせよ defaults 方式ではキャプション名も defaults file 側で管理するため、
-    // appendLabelOverrides はスキップする（builtin + crossref-OFF のみ注入）。
-    const headerWithListings =
-      isDefaultsMode || activeProfile.usePandocCrossref
-        ? withCallout
-        : appendLabelOverrides(withCallout, {
-            figureLabel: activeProfile.figureLabel,
-            figPrefix: activeProfile.figPrefix,
-            tableLabel: activeProfile.tableLabel,
-            tblPrefix: activeProfile.tblPrefix,
-            codeLabel: activeProfile.codeLabel,
-            lstPrefix: activeProfile.lstPrefix,
-            equationLabel: activeProfile.equationLabel,
-            eqnPrefix: activeProfile.eqnPrefix,
-          });
-
-    //
-    // LaTeX の \maketitle はタイトルページを強制的に plain スタイルにする。
-    // ページ番号をオフにしても、plain スタイルのままだと1ページ目だけ数字が出る。
-    // plain → empty に差し替えてタイトルページも無番号に統一する。
-    // defaults 方式ではページ番号制御も defaults file 側で管理するためスキップする。
-    const pageNumberSnippet =
-      isDefaultsMode || activeProfile.usePageNumber
-        ? ""
-        : "\\makeatletter\\let\\ps@plain\\ps@empty\\makeatother";
-
-    const draftSnippet = draftRequested
-      ? [
-          "\\def\\isdraft{1}",
-          "\\PassOptionsToPackage{draft}{graphicx}",
-          "\\makeatletter\\Gin@drafttrue\\makeatother",
-        ].join("\n")
-      : "";
-
-    const headerWithoutDraft = pageNumberSnippet
-      ? `${pageNumberSnippet}\n${headerWithListings}`
-      : headerWithListings;
-
-    const headerWithDraftFlag = draftSnippet
-      ? `${draftSnippet}\n${headerWithoutDraft}`
-      : headerWithoutDraft;
+    // ヘッダ（--include-in-header の中身）の組み立ては純粋関数 buildHeader に切り出している。
+    // 文書テンプレート方式（ADR-007）の分岐、CALLOUT_PREAMBLE 付与、codelisting 補完、
+    // label overrides、ページ番号スニペット、draft スニペットの各段とその根拠は
+    // buildHeader 側に集約済み（issue #51）。ここでは方式の解決と draft フラグだけ渡す。
+    // defaults 方式は文書の「枠」（プリアンブル本体・キャプション名・ページ番号）を defaults
+    // file 側で管理する一方、CALLOUT_PREAMBLE / codelisting / draftSnippet は MdTex 固有
+    // レイヤとして方式に関わらず buildHeader 内で維持する。
+    const mode = isDefaultsTemplateMode(activeProfile) ? "defaults" : "builtin";
+    const headerContent = buildHeader(activeProfile, { mode, draft: draftRequested });
     // LaTeX生ファイルとして include-in-header で渡す（Markdown経由のエスケープを防ぐ）
-    await fs.writeFile(headerFilePath, `${headerWithDraftFlag}\n`, "utf8");
+    await fs.writeFile(headerFilePath, `${headerContent}\n`, "utf8");
 
     // 有効な WikiLink のみ [[ ]] を外してテキストにする
     content = unwrapValidWikiLinks(content, ctx.app, activeFile.path);

--- a/src/utils/headerBuilder.test.ts
+++ b/src/utils/headerBuilder.test.ts
@@ -1,0 +1,207 @@
+// File: src/utils/headerBuilder.test.ts
+// Purpose: buildHeader 純粋関数が 5 段階（codelisting 補完 / callout preamble / label
+//   overrides / page number snippet / draft snippet）を正しく組み立てることを検証する。
+// Reason: convertCurrentPage から切り出したヘッダ構築ロジックを、I/O や Pandoc 実行に
+//   依存せず header 内容単位でテスト可能にするため（issue #51）。
+// Related: src/utils/headerBuilder.ts, src/services/convertService.ts, src/utils/latexPreamble.ts
+
+import { describe, expect, it } from "vitest";
+import { buildHeader } from "./headerBuilder";
+import { DEFAULT_PROFILE, DEFAULT_LATEX_PREAMBLE } from "../MdTexPluginSettings";
+import { CALLOUT_PREAMBLE } from "./calloutTheme";
+import type { ProfileSettings } from "../MdTexPluginSettings";
+
+// DEFAULT_PROFILE をベースに任意フィールドだけ上書きするヘルパー。
+function profile(overrides: Partial<ProfileSettings> = {}): ProfileSettings {
+  return { ...DEFAULT_PROFILE, ...overrides };
+}
+
+describe("buildHeader", () => {
+  it("callout preamble と codelisting 補完を常に含む（方式/crossref/ページ番号に関わらない共通レイヤ）", () => {
+    // MdTex 固有レイヤ: CALLOUT_PREAMBLE（obsidiancallout 定義）と codelisting 環境定義は
+    // 方式に関わらず維持される。これらは --include-in-header の最低限の内容。
+    const out = buildHeader(profile(), { mode: "builtin", draft: false });
+    expect(out).toContain("obsidiancallout"); // CALLOUT_PREAMBLE 由来
+    expect(out).toContain("\\usepackage{newfloat}"); // codelisting 補完
+    expect(out).toMatch(/\]\s*\{codelisting\}/);
+  });
+
+  it("末尾改行を含まない（呼び出し側が付与する）", () => {
+    const out = buildHeader(profile(), { mode: "builtin", draft: false });
+    expect(out.endsWith("\n")).toBe(false);
+  });
+
+  describe("label overrides（crossref / defaults 方式の分岐）", () => {
+    it("builtin + crossref-ON では \\renewcommand を注入しない（メタデータ経路に一本化）", () => {
+      const out = buildHeader(
+        profile({ usePandocCrossref: true }),
+        { mode: "builtin", draft: false },
+      );
+      expect(out).not.toContain("\\renewcommand{\\figurename}");
+      expect(out).not.toContain("\\renewcommand{\\tablename}");
+    });
+
+    it("builtin + crossref-OFF ではプロファイル値で \\renewcommand を注入するフォールバック", () => {
+      const out = buildHeader(
+        profile({
+          usePandocCrossref: false,
+          figureLabel: "図",
+          tableLabel: "表",
+        }),
+        { mode: "builtin", draft: false },
+      );
+      expect(out).toContain("\\renewcommand{\\figurename}{図}");
+      expect(out).toContain("\\renewcommand{\\tablename}{表}");
+      // makeatletter で安全に囲まれる
+      expect(out).toContain("\\makeatletter");
+      expect(out).toContain("\\makeatother");
+    });
+
+    it("defaults 方式ではキャプション名も defaults file 側で管理するため \\renewcommand を注入しない", () => {
+      const out = buildHeader(
+        profile({ usePandocCrossref: false, figureLabel: "図" }),
+        { mode: "defaults", draft: false },
+      );
+      expect(out).not.toContain("\\renewcommand{\\figurename}");
+    });
+  });
+
+  describe("baseHeader（方式によるプリアンブル本体の扱い）", () => {
+    it("builtin 方式では headerIncludes（DEFAULT_LATEX_PREAMBLE 本体）を含む", () => {
+      const out = buildHeader(profile(), { mode: "builtin", draft: false });
+      // DEFAULT_LATEX_PREAMBLE の目印（luatexja-fontspec）が含まれる
+      expect(out).toContain("luatexja-fontspec");
+    });
+
+    it("defaults 方式では headerIncludes（baseHeader）を含まず、CALLOUT+codelisting のみ", () => {
+      // defaults 方式はプリアンブル本体を defaults file 側で管理するため、baseHeader は空扱い。
+      const out = buildHeader(profile(), { mode: "defaults", draft: false });
+      expect(out).not.toContain("luatexja-fontspec"); // baseHeader（DEFAULT_LATEX_PREAMBLE）は含まない
+      // MdTex 固有レイヤは維持
+      expect(out).toContain("obsidiancallout");
+      expect(out).toContain("\\usepackage{newfloat}");
+    });
+
+    it("headerIncludes が既に obsidiancallout を含む場合はコールアウト定義を二重付与しない", () => {
+      // ユーザーが独自プリアンブルで既にコールアウト定義を持つ場合、CALLOUT_PREAMBLE を
+      // 重ねて追加しないことを検証する。
+      const customHeaderIncludes = "% my custom preamble\n\\newtcolorbox{obsidiancallout}[1]{}";
+      const out = buildHeader(
+        profile({ headerIncludes: customHeaderIncludes }),
+        { mode: "builtin", draft: false },
+      );
+      // CALLOUT_PREAMBLE の固有目印（fontawesome5 / callout-bg）は追加されない
+      expect(out).not.toContain("fontawesome5");
+      expect(out).not.toContain("callout-bg");
+      // ユーザー定義はそのまま残る
+      expect(out).toContain("my custom preamble");
+    });
+
+    it("headerIncludes に obsidiancallout が無い場合は CALLOUT_PREAMBLE を付与する", () => {
+      const out = buildHeader(
+        profile({ headerIncludes: "% minimal preamble\n\\usepackage{listings}" }),
+        { mode: "builtin", draft: false },
+      );
+      // CALLOUT_PREAMBLE の固有目印が含まれる
+      expect(out).toContain("fontawesome5");
+      expect(out).toContain("obsidiancallout");
+    });
+  });
+
+  describe("pageNumberSnippet（タイトルページ無番号化）", () => {
+    it("usePageNumber=true ではページ番号スニペットを注入しない", () => {
+      const out = buildHeader(
+        profile({ usePageNumber: true }),
+        { mode: "builtin", draft: false },
+      );
+      expect(out).not.toContain("\\let\\ps@plain\\ps@empty");
+    });
+
+    it("usePageNumber=false では plain→empty 差し替えスニペットを注入する", () => {
+      // ページ番号をオフにしても \maketitle の plain スタイルだと1ページ目に数字が出るため、
+      // plain を empty に差し替えてタイトルページも無番号に統一する。
+      const out = buildHeader(
+        profile({ usePageNumber: false }),
+        { mode: "builtin", draft: false },
+      );
+      expect(out).toContain("\\makeatletter\\let\\ps@plain\\ps@empty\\makeatother");
+    });
+
+    it("defaults 方式ではページ番号制御も defaults file 側のためスニペットを注入しない", () => {
+      const out = buildHeader(
+        profile({ usePageNumber: false }),
+        { mode: "defaults", draft: false },
+      );
+      expect(out).not.toContain("\\let\\ps@plain\\ps@empty");
+    });
+  });
+
+  describe("draftSnippet（graphicx draft 化）", () => {
+    it("draft=false では draft スニペットを含まない", () => {
+      const out = buildHeader(profile(), { mode: "builtin", draft: false });
+      expect(out).not.toContain("\\def\\isdraft{1}");
+      expect(out).not.toContain("\\Gin@drafttrue");
+    });
+
+    it("draft=true では graphicx draft スニペットをヘッダ先頭に付与する", () => {
+      const out = buildHeader(profile(), { mode: "builtin", draft: true });
+      expect(out).toContain("\\def\\isdraft{1}");
+      expect(out).toContain("\\PassOptionsToPackage{draft}{graphicx}");
+      expect(out).toContain("\\makeatletter\\Gin@drafttrue\\makeatother");
+      // draft スニペットは本体より前に来る
+      expect(out.indexOf("\\def\\isdraft{1}")).toBeLessThan(out.indexOf("obsidiancallout"));
+    });
+  });
+
+  describe("段の組み合わせ（統合）", () => {
+    it("crossref-OFF + ページ番号OFF + draft を全て同時に指定したヘッダを組み立てる", () => {
+      // 全段が有効になる設定での構造を検証。順序は draft → pageNumberSnippet → 本体。
+      const out = buildHeader(
+        profile({
+          usePandocCrossref: false,
+          usePageNumber: false,
+          figureLabel: "図",
+        }),
+        { mode: "builtin", draft: true },
+      );
+
+      const draftIdx = out.indexOf("\\def\\isdraft{1}");
+      const pageIdx = out.indexOf("\\let\\ps@plain\\ps@empty");
+      const labelIdx = out.indexOf("\\renewcommand{\\figurename}{図}");
+      const calloutIdx = out.indexOf("obsidiancallout");
+
+      expect(draftIdx).toBeGreaterThan(-1);
+      expect(pageIdx).toBeGreaterThan(-1);
+      expect(labelIdx).toBeGreaterThan(-1);
+      expect(calloutIdx).toBeGreaterThan(-1);
+
+      // draft → pageNumberSnippet → (label overrides / callout) の順
+      expect(draftIdx).toBeLessThan(pageIdx);
+      expect(pageIdx).toBeLessThan(calloutIdx);
+    });
+  });
+
+  describe("convertCurrentPage の既存挙動との後方互換（回帰ガード）", () => {
+    it("DEFAULT_PROFILE は既に codelisting 定義済みのため ensureCodelistingEnvironment は冪等", () => {
+      // DEFAULT_LATEX_PREAMBLE には codelisting 定義が含まれるため、補完で二重定義しない。
+      const out = buildHeader(profile(), { mode: "builtin", draft: false });
+      // DeclareFloatingEnvironment は1回だけ
+      const matches = out.match(/\\DeclareFloatingEnvironment/g) || [];
+      expect(matches.length).toBe(1);
+    });
+
+    it("DEFAULT_PROFILE の builtin 既定ヘッダは callout+codelisting+preamble 本体 を含む", () => {
+      // デフォルト設定で生成されるヘッダの構成要素をスナップショット的に担保。
+      const out = buildHeader(profile(), { mode: "builtin", draft: false });
+      expect(out).toContain(DEFAULT_LATEX_PREAMBLE.trim().slice(0, 40)); // preamble 本体の先頭
+      expect(out).toContain("obsidiancallout");
+      expect(out).toContain("\\usepackage{newfloat}");
+    });
+
+    it("CALLOUT_PREAMBLE の内容が builtin 既定で含まれる（fontawesome5 等）", () => {
+      const out = buildHeader(profile(), { mode: "builtin", draft: false });
+      expect(out).toContain("fontawesome5");
+      expect(out).toContain(CALLOUT_PREAMBLE.trim().slice(0, 30));
+    });
+  });
+});

--- a/src/utils/headerBuilder.ts
+++ b/src/utils/headerBuilder.ts
@@ -1,0 +1,115 @@
+// File: src/utils/headerBuilder.ts
+// Purpose: --include-in-header に渡す LaTeX ヘッダ全体を組み立てる純粋関数を提供する。
+// Reason: convertCurrentPage の orchestration（Pandoc 実行・I/O・例外処理）からヘッダ構築
+//   ロジックを分離し、段階ごとの意味（codelisting 補完・callout preamble・label overrides・
+//   ページ番号スニペット・draft スニペット）を独立してテスト可能にするため（issue #51）。
+// Related: src/services/convertService.ts, src/utils/latexPreamble.ts, src/utils/calloutTheme.ts, src/MdTexPluginSettings.ts
+
+import { ProfileSettings } from "../MdTexPluginSettings";
+import { appendLabelOverrides, ensureCodelistingEnvironment } from "./latexPreamble";
+import { CALLOUT_PREAMBLE } from "./calloutTheme";
+
+/**
+ * ヘッダ組み立てに必要なオプション。
+ *
+ * - `mode`: 文書テンプレート方式（ADR-007）。`"defaults"` のとき文書の「枠」（プリアンブル
+ *   本体・キャプション名・ページ番号）は defaults file 側で管理するため、これらの段を
+ *   スキップし、CALLOUT_PREAMBLE と codelisting 補完だけを残す。
+ * - `draft`: draft モードか（`--draft` 引数または frontmatter `mdtex.draft`）。true のとき
+ *   graphicx draft スニペットをヘッダ先頭に付与する。
+ */
+export interface BuildHeaderOptions {
+  mode: "builtin" | "defaults";
+  draft: boolean;
+}
+
+/**
+ * --include-in-header に渡す LaTeX ヘッダ全体を組み立てる純粋関数（issue #51）。
+ *
+ * 以下の 5 段階の変換を順に適用し、1 つの文字列にまとめる:
+ * 1. baseHeader        : ユーザー設定プリアンブル（defaults 方式では空）
+ * 2. withCallout       : Obsidian コールアウト定義（CALLOUT_PREAMBLE）の付与と、codelisting
+ *                        浮動体環境（Pandoc 3.8+ の --listings 互換）の補完
+ * 3. headerWithListings: crossref-OFF 時のキャプション語 \renewcommand フォールバック
+ * 4. pageNumberSnippet : usePageNumber=OFF 時の plain→empty 差し替え（タイトルページ無番号化）
+ * 5. draftSnippet      : draft モード時の graphicx draft スニペット
+ *
+ * 方式（mode）の意味付けと各段の根拠は関数内のコメントを参照。純粋関数のため
+ * I/O を持たず、ユニットテストで header 内容を直接検証できる。
+ *
+ * @returns ヘッダファイルに書き出す LaTeX 文字列（末尾改行は含まない。呼び出し側で付与）
+ */
+export function buildHeader(
+  profile: ProfileSettings,
+  options: BuildHeaderOptions,
+): string {
+  const { mode, draft } = options;
+  const isDefaultsMode = mode === "defaults";
+
+  // --- 1. baseHeader ---
+  // defaults 方式では headerIncludes も defaults file 側の include-in-header で管理するため
+  // 空扱いとし、CALLOUT_PREAMBLE と codelisting 定義だけを残す。
+  const baseHeader = isDefaultsMode ? "" : profile.headerIncludes || "";
+
+  // --- 2. withCallout（callout preamble 付与 + codelisting 補完）---
+  // ユーザー設定プリアンブルにコールアウト定義を付与する。プリアンブルは生 .tex として
+  // --include-in-header で渡すため、YAML(header-includes) 時代のクリーニングは行わず、
+  // ユーザー設定 + コールアウト定義をそのまま素通りさせる。既に obsidiancallout が含まれて
+  // いる場合は二重定義を避けて追加しない。
+  const withCalloutBase = baseHeader.includes("obsidiancallout")
+    ? baseHeader
+    : `${baseHeader.trim()}\n\n${CALLOUT_PREAMBLE}`.trim();
+  // Pandoc 3.8+ は --listings 時にキャプション付きコードブロックを \begin{codelisting} で
+  // 出力する。codelisting 環境は DEFAULT_LATEX_PREAMBLE に定義済みだが、旧版からの移行等で
+  // 独自プリアンブルを持つ場合は定義が欠け「Environment codelisting undefined.」で停止するため、
+  // 欠けていれば冪等に補完する。defaults 方式でも --listings を常時付与するため補完は維持する。
+  const withCallout = ensureCodelistingEnvironment(withCalloutBase);
+
+  // --- 3. headerWithListings（label overrides）---
+  // crossref-ON 時はキャプション語／参照接頭辞をメタデータ経路（--metadata-file /
+  // frontmatter）に一本化し、\renewcommand との二重管理を避ける。crossref-OFF 時は
+  // メタデータの消費先がないため、プロファイル値で LaTeX ネイティブのキャプション名
+  // （\figurename 等）を上書きするフォールバックを残す。defaults 方式ではキャプション名も
+  // defaults file 側で管理するため appendLabelOverrides はスキップする（builtin + crossref-OFF
+  // のみ注入）。
+  const headerWithListings =
+    isDefaultsMode || profile.usePandocCrossref
+      ? withCallout
+      : appendLabelOverrides(withCallout, {
+          figureLabel: profile.figureLabel,
+          figPrefix: profile.figPrefix,
+          tableLabel: profile.tableLabel,
+          tblPrefix: profile.tblPrefix,
+          codeLabel: profile.codeLabel,
+          lstPrefix: profile.lstPrefix,
+          equationLabel: profile.equationLabel,
+          eqnPrefix: profile.eqnPrefix,
+        });
+
+  // --- 4. pageNumberSnippet ---
+  // LaTeX の \maketitle はタイトルページを強制的に plain スタイルにする。ページ番号を
+  // オフにしても、plain スタイルのままだと1ページ目だけ数字が出る。plain → empty に
+  // 差し替えてタイトルページも無番号に統一する。defaults 方式ではページ番号制御も
+  // defaults file 側で管理するためスキップする。
+  const pageNumberSnippet =
+    isDefaultsMode || profile.usePageNumber
+      ? ""
+      : "\\makeatletter\\let\\ps@plain\\ps@empty\\makeatother";
+
+  // --- 5. draftSnippet ---
+  // draft モード時、graphicx に draft オプションを渡して画像をプレースホルダ化する。
+  const draftSnippet = draft
+    ? [
+        "\\def\\isdraft{1}",
+        "\\PassOptionsToPackage{draft}{graphicx}",
+        "\\makeatletter\\Gin@drafttrue\\makeatother",
+      ].join("\n")
+    : "";
+
+  // 結合: draft スニペット → ページ番号スニペット → 本体 の順。
+  // いずれも独立した LaTeX 文であり順序依存がないため、存在する段だけ改行で繋ぐ
+  //（headerWithListings は常に非空なので join 結果が空になることはない）。
+  return [draftSnippet, pageNumberSnippet, headerWithListings]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,6 +33,12 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
     passWithNoTests: true,
+    // 実プロセスを起動する統合テスト（lualatex による PDF コンパイル、pandoc、
+    // mermaid DOM rasterization 等）は冷備え/並列負荷で 5s 既定を超え得る。
+    // 特に DEFAULT_LATEX_PREAMBLE（luatexja-fontspec + unicode-math 等の重いプリアンブル）を
+    // コンパイルする codelisting 統合テストは ~4.6s かかり、フルスイート並列実行下で
+    // ギリギリになるため、push/CI ゲートが非決定的になるのを防ぐため十分な頭長を確保する。
+    testTimeout: 30000,
     coverage: {
       provider: "v8",
     },


### PR DESCRIPTION
## 概要

`convertCurrentPage` 内に埋め込まれていた header 構築ロジック（4 段階の条件付き文字列結合: baseHeader → withCallout → headerWithListings → headerWithoutDraft → headerWithDraftFlag）を orchestration（Pandoc 実行・I/O・例外処理）から切り出し、純粋関数 `buildHeader(profile, { mode, draft }): string` として `src/utils/headerBuilder.ts` に集約しました。サーモニュークリア・レビューの P1 所見対応です。

Closes https://github.com/Mekann2904/obsidian-mdtex-plugin/issues/51

## 変更内容

### 新規: `src/utils/headerBuilder.ts`
純粋関数 `buildHeader(profile, options)` を追加。5 段階の変換を 1 関数内で明示的に扱います:
1. **baseHeader** — ユーザー設定プリアンブル（defaults 方式では空）
2. **withCallout** — callout preamble（`CALLOUT_PREAMBLE`）付与 + codelisting 浮動体環境の補完（Pandoc 3.8+ の `--listings` 互換）
3. **headerWithListings** — crossref-OFF 時のキャプション語 `\renewcommand` フォールバック（label overrides）
4. **pageNumberSnippet** — `usePageNumber=OFF` 時の plain→empty 差し替え（タイトルページ無番号化）
5. **draftSnippet** — draft モード時の graphicx draft スニペット

各段には ADR-007 / Pandoc 3.8+ 互換 / メタデータ経路一本化等の根拠コメントを保持。

### 新規: `src/utils/headerBuilder.test.ts`
header 内容のユニットテスト 18 件を追加:
- codelisting 補完 / callout preamble 付与 / label overrides / page number snippet / draft snippet の各段
- builtin / defaults 方式の分岐
- crossref-ON/OFF の分岐
- 二重 callout ガード（既存 obsidiancallout 定義の尊重）
- 冪等性・順序・後方互換スナップショット

### 変更: `src/services/convertService.ts`
`convertCurrentPage` のヘッダ構築ブロック（約 60 行）を `buildHeader` 呼び出しに集約し、未使用になった import（`appendLabelOverrides` / `ensureCodelistingEnvironment` / `CALLOUT_PREAMBLE`）を整理。

### 変更: `vitest.config.ts`（テスト基盤の安定化、本 issue と無関係だが push ゲート通過のため同梱）
実プロセスを起動する統合テスト（lualatex PDF コンパイル等）が既定の 5s タイムアウトを使っており、フルスイート並列実行下（pre-push フック）で codelisting 統合テストがタイムアウトして push ゲートが非決定的になっていたため `testTimeout: 30000` を追加。検証内容は不変。

## Acceptance criteria

- [x] header 組み立てが `convertCurrentPage` から切り出され、純粋関数になる
- [x] codelisting 補完 / callout preamble 付与 / label overrides / page number snippet / draft snippet の各段が 1 関数内で明示的に扱われる
- [x] header 内容のユニットテストが追加される（18 件）
- [x] 変換パイプラインの挙動が変わらない（テスト全通過）

## 検証

- `npx vitest run` → **229 / 229 合格**（headerBuilder 18 件 + 既存 211 件）
- `npx tsc -noEmit -skipLibCheck` → クリーン
- `npx eslint src/utils/headerBuilder.ts src/utils/headerBuilder.test.ts` → エラーなし
- review_fixer（thermo-nuclear review）→ APPROVE 相当。最終結合を `filter(Boolean).join` に簡素化（挙動等価）。
- 挙動不変の回帰ガード: 既存の end-to-end `convertService.test.ts`（実 `.preamble.tex` を読んで builtin/defaults 両方式を検証）がそのまま合格。

## 設計メモ

署名 `buildHeader(profile, { mode, draft })` は issue 本文の明示指定通り維持。`mode` は `profile.documentTemplateMode` から導出可能だが、明示パラメータにすることで `buildHeader` を settings の policy 関数（`isDefaultsTemplateMode`）から疎結合に保ち、テストで方式を直接指定できるようにしています。

## 備考

- 既存の lint error（`normalizeTemplateFolder` 未使用 import in `convertService.ts`）は base commit `4d1dd31` から存在する本 PR と無関係の既存問題のため未対応（別 issue 推奨）。