### PR TITLE
refactor: getInputFormatArgs の dead parameter を廃止し定数化 (#52)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -260,7 +260,6 @@ export function renameProfile(profiles: Record<string, ProfileSettings>, oldName
 
 ```typescript
 export function buildPandocCommand(options: PandocCommandOptions): PandocCommandResult
-export function getInputFormatArgs(format: OutputFormat): string[]
 ```
 
 ### ProcessRunner

--- a/src/services/pandocCommandBuilder.ts
+++ b/src/services/pandocCommandBuilder.ts
@@ -38,7 +38,7 @@ export function buildPandocCommand(options: PandocCommandOptions): PandocCommand
     args.push(normalizeFsPath(options.inputPath));
   }
 
-  args.push(...getInputFormatArgs(options.format));
+  args.push(...INPUT_FORMAT_ARGS);
 
   // 文書テンプレート方式（ADR-007 / ADR-008）: defaults 方式は defaults file（`-d`）に文書の「枠」を委譲する。
   // コマンドライン `-V` は defaults file より優先されてしまうため、documentclass 系の `-V` は
@@ -168,7 +168,7 @@ export function buildLabelMetadataYaml(profile: ProfileSettings): string {
 }
 
 /**
- * Pandoc の入力フォーマット引数（`-f`）を返す。
+ * Pandoc の入力フォーマット引数（`-f`）。
  *
  * 全出力形式（pdf/latex/docx）で共通の Markdown 拡張セットを明示する。
  * Pandoc 3.x のデフォルト `markdown` は `+raw_tex +raw_html +fenced_divs
@@ -177,14 +177,11 @@ export function buildLabelMetadataYaml(profile: ProfileSettings): string {
  * （生 LaTeX / `:::` fenced div / `{=latex}` `{=openxml}` raw block /
  * `{#lst:...}` コード属性）を Pandoc のバージョン差や設定ドリフトに
  * 依存せず安定して有効化するため明示する。
- *
- * `format` は歴史的に出力形式ごとの分岐に使われていた引数だが、現状は
- * すべて同じ結果を返す。呼び出し側（`buildPandocCommand`）の意図と API
- * 安定性を保つため受け取り続け、分岐は行わない。
  */
-export function getInputFormatArgs(format: string): string[] {
-  return ["-f", "markdown+raw_tex+raw_html+fenced_divs+raw_attribute+fenced_code_attributes"];
-}
+const INPUT_FORMAT_ARGS: readonly string[] = [
+  "-f",
+  "markdown+raw_tex+raw_html+fenced_divs+raw_attribute+fenced_code_attributes",
+];
 
 export function filterPandocExtrasForFormat(extras: string[], format: string): string[] {
   if (!extras.length) return [];


### PR DESCRIPTION
## 概要

`pandocCommandBuilder.ts` の `getInputFormatArgs(format)` は `format` 引数を受け取るが関数内で全く使わず、常に同じ Markdown 拡張セットの配列を返す thin wrapper だった。内部純粋関数に API 安定性の言い訳は妥当しないため、`readonly string[]` のモジュール定数 `INPUT_FORMAT_ARGS` に置換した。

Closes #52

## 変更内容

- `src/services/pandocCommandBuilder.ts`
  - `getInputFormatArgs(format: string): string[]` 関数を `const INPUT_FORMAT_ARGS: readonly string[]` に置換
  - 呼び出し側を `args.push(...INPUT_FORMAT_ARGS)` に変更（`format` 引数の受け渡しを削除）
  - 補完拡張セットの根拠ドキュメントは維持、dead parameter の言い訳段落のみ削除
- `ARCHITECTURE.md`
  - PandocCommandBuilder の公開 API 一覧から `getInputFormatArgs` を除去

## Acceptance criteria

- [x] `getInputFormatArgs(format)` が定数 `INPUT_FORMAT_ARGS` に置き換えられる
- [x] 呼び出し側が `args.push(...INPUT_FORMAT_ARGS)` のように定数を直接参照する
- [x] 不要になった `format` 引数の受け渡しが削除される
- [x] 既存テスト（`pandocCommandBuilder.test.ts` 含む）が全て通る

## 設計上のポイント

- 生成される Pandoc コマンド引数は **byte-identical**（返す配列の内容は同一のため回帰なし）
- `readonly string[]` で不変性を型レベルで表現し、意図せぬ破壊的変更を防止
- 定数は最小差分を優先し、元の関数位置に docstring 付きで配置（コードベース全体で `getInputFormatArgs` への外部参照は `rg` で確認済み: 0 件 → export 不要）

## 検証

- `tsc --noEmit`: **CLEAN**
- `prettier --check`: **OK**
- `eslint src/services/pandocCommandBuilder.ts`: **CLEAN**（※リポジトリ既存の `MdTexPluginSettings.ts` / `convertService.ts` のエラーは本 PR と無関係）
- `vitest run src/services/pandocCommandBuilder.test.ts`: **16/16 passed**
- `vitest run`（フルスイート）: **220/220 passed**

> 補足: `codelisting.integration.test.ts` は実機 lualatex 起動で ~4.5-5.0s かかり、デフォルトの 5s タイムアウト境界付近を振動する環境依存の flaky テスト。本変更は `-f` 引数が byte-identical なため論理的に無関係（`git stash` によるベースライン比較と複数回実行で確認）。

## ワークツリーに関するメモ（メンテナ向け）

本 worktree には **issue-52 と無関係な変更が並行プロセス由来で混入**していました。これらは **本 PR に含めず、未コミットのまま保護・保持**しています（破棄していません）:
- `src/services/convertService.ts`（大幅リファクタ）
- `src/services/tempFiles.ts` / `tempFiles.test.ts`（新規モジュール、untracked）
- `CHANGELOG.md`

これらは別 Issue（temp-file 管理系）の作業と思われます。別ブランチ/PR として切り出す必要があります。