### PR TITLE
fix(lint): lint gate を build に組込み preamble escape と未使用 import を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "dev": "node esbuild.config.mjs",
-    "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+    "build": "npm run lint && tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "version": "node version-bump.mjs && git add manifest.json versions.json",
     "prepare": "husky",
     "test": "vitest",

--- a/src/MdTexPluginSettings.ts
+++ b/src/MdTexPluginSettings.ts
@@ -223,7 +223,7 @@ export const DEFAULT_LATEX_PREAMBLE = `\\providecommand{\\passthrough}[1]{#1}
 }
 
 % codelisting 浮動体環境（Pandoc 3.8+ の --listings 互換）
-% Pandoc 3.8 以降はキャプション付きコードブロックを \begin{codelisting}...\end{codelisting}
+% Pandoc 3.8 以降はキャプション付きコードブロックを \\begin{codelisting}...\\end{codelisting}
 % として出力するが、codelisting 環境は listings パッケージに含まれず newfloat で別途
 % 定義が必要。これがないと「! LaTeX Error: Environment codelisting undefined.」で
 % PDF 生成が停止する。pandoc-crossref の Listing 参照や cleveref とも整合する。

--- a/src/services/convertService.ts
+++ b/src/services/convertService.ts
@@ -31,10 +31,7 @@ import {
 } from "./pandocCommandBuilder";
 import { runCommand } from "../utils/processRunner";
 import { joinFsPath, normalizeResourcePathList } from "../utils/pathHelpers";
-import {
-  resolveDefaultsFilePath,
-  normalizeTemplateFolder,
-} from "./templatePackService";
+import { resolveDefaultsFilePath } from "./templatePackService";
 
 export interface ConvertDeps {
   runMarkdownlintFix: (ctx: PluginContext, targetPath: string) => Promise<void>;

--- a/src/utils/codelisting.integration.test.ts
+++ b/src/utils/codelisting.integration.test.ts
@@ -27,7 +27,11 @@ function lualatexAvailable(): boolean {
   }
 }
 
-const it_lua = lualatexAvailable() ? it : it.skip;
+// lualatex の PDF コンパイルは（初回フォントキャッシュ構築等もあり）4–6s 程を要する。
+// vitest 既定の testTimeout 5000ms では負荷時に timerace で落ちるため、十分な猶予を持たせる。
+const LUALATEX_TEST_TIMEOUT = 30000;
+const it_lua = (name: string, fn: () => void) =>
+  (lualatexAvailable() ? it : it.skip)(name, fn, LUALATEX_TEST_TIMEOUT);
 
 // DEFAULT_LATEX_PREAMBLE は --include-in-header 相当（\documentclass を持たない）。
 // codelisting 検証に集中するため、別件の unicode-math/amssymb 衝突を回避して組み立てる。


### PR DESCRIPTION
## 概要

サーモニュークリア・レビューで発見された lint gate の欠落と regression を修正し、今後の滑り落ちを防ぐ gate を強化します。Closes #53。

## 背景

`npm run lint` が 2 件の error で落ちていたが、pre-commit フックが lint を含まないため検出されず残置されていた。

- `DEFAULT_LATEX_PREAMBLE` のコメント行で template literal 内に単一 `\` があり、`\b` が backspace（U+0008）、`\e` が `e` に化けていた（`%` コメント内なので PDF には無害だが文字列として破損、`no-useless-escape` で指摘）
- 変換サービスに未使用 import が残置
- pre-commit が `npm run build`（tsc + esbuild）のみで lint を含まない

## 変更内容（4 ファイル, +8 / -7）

- **`package.json`** — `build` スクリプト先頭に `npm run lint &&` を前置。pre-commit / pre-push はいずれも `npm run build` を呼ぶため、これひとつで **commit / build / CI release の全経路** で lint 失敗時に停止する（単一の真実源）。新規スクリプトや抽象は増やさない。
- **`src/MdTexPluginSettings.ts`** — コメント行 `\begin{codelisting}...\end{codelisting}` を `\\begin...\\end` に修正。本来の LaTeX 命令行（`\\usepackage` 等）は触らない。
- **`src/services/convertService.ts`** — 未使用 import `normalizeTemplateFolder` を除去（`resolveDefaultsFilePath` は継続使用のため残置）。
- **`src/utils/codelisting.integration.test.ts`** — lualatex PDF コンパイル（実測 4–6s）が vitest 既定 `testTimeout` 5000ms の境界で負荷時に timerace 落ちしていたため 30000ms を設定。CI では lualatex 非インストール時に自動スキップされるため影響なし。acceptance「既存テスト 211 個が全て通る」を堅牢化。

## Acceptance criteria

- [x] `npm run lint` が error 0 で通る
- [x] template literal 内のコメント行の `\` がすべて `\\` に修正され、実行時の文字列に backspace 等の制御文字が混入しない（実機検証: 制御文字 0 件、codelisting 行は正しく `\begin{codelisting}...\end{codelisting}` に復元）
- [x] 未使用 import が除去されている
- [x] build スクリプトに lint が組み込まれ、lint 失敗時に commit/build が止まる（負荷検証: lint error 注入 → build exit 1 で tsc/esbuild 未到達）
- [x] 既存テスト（211 個）が全て通る

## 検証

| 項目 | 結果 |
|---|---|
| `npm run lint` | exit 0（error 0 / warning 0） |
| `npm run build`（lint 含む） | exit 0 end-to-end |
| lint gate 負荷検証 | lint error 注入 → build exit 1 で停止 → リバート後復帰 |
| 実行時文字列健全性 | 制御文字 0 件 |
| `npm test` | **211 / 211 passed**（18 files） |

review_fixer による thermo-nuclear review: **Approve（修正不要）**。